### PR TITLE
Bumping Python version to 3.9

### DIFF
--- a/{{cookiecutter.project_name}}/template.yaml
+++ b/{{cookiecutter.project_name}}/template.yaml
@@ -8,7 +8,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: src/app.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.9
       CodeUri: .
       Description: Uses Rekognition APIs to detect text in S3 Objects and stores the text and labels in DynamoDB.
       MemorySize: 512


### PR DESCRIPTION
Otherwise, this template fails to work as per:
https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-example-s3.html#serverless-example-s3-prereq

Error in output generated by `sam deploy` of the linked tutorial:
```
CREATE_FAILED                 AWS::Lambda::Function         DetectTextInImage             Resource handler returned   
                                                                                          message: "The runtime       
                                                                                          parameter of python3.6 is   
                                                                                          no longer supported for     
                                                                                          creating or updating AWS    
                                                                                          Lambda functions. We        
                                                                                          recommend you use the new   
                                                                                          runtime (python3.9) while   
                                                                                          creating or updating        
                                                                                          functions. (Service:        
                                                                                          Lambda, Status Code: 400, 
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
